### PR TITLE
Changed hyperlinks to latest and archived site directory for PR builds

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -18,6 +18,8 @@ node('ubuntu18.04-OnDemand'){
     """
     } else {
       sh 'mkdocs build'
+      print "Archiving site directory"
+      archiveArtifacts artifacts: 'site/**/*', fingerprint: true, allowEmptyArchive: false
       echo 'Deployment to gh-pages is done only from master branch'
     }
   }

--- a/homepage/docs/index.md
+++ b/homepage/docs/index.md
@@ -5,4 +5,4 @@ implementations for FIDO Device Onboard specification.
 
 Following snapshots are available for different releases of FIDO Device Onboard implementations.
 
-* [0.5](https://secure-device-onboard.github.io/docs-fidoiot/0.5.0)
+* [latest](https://secure-device-onboard.github.io/docs-fidoiot/latest)


### PR DESCRIPTION
This PR contains the following changes:

- Updating the hyperlinks from 0.5 to 'latest' in `homepage/docs/index.md`
- Archiving `site` directory in `Jenkinsfile.yml`