### PR TITLE
Fixed CSDK Typos, image path and default flags

### DIFF
--- a/docs/client-sdk/client-sdk-design.md
+++ b/docs/client-sdk/client-sdk-design.md
@@ -43,7 +43,7 @@ Currently, all manufacturer information and device secrets are stored in persist
 
 All file save and load APIs must be rewritten using CBOR-COSE APIs to replace JSON encoding and decoding.
 
-### Fido Message Handling 
+### FIDO Message Handling 
 
 The following is the detailed design for handling FDO CBOR messages in the Client SDK implementation. 
 

--- a/docs/client-sdk/client-sdk-porting-guide.md
+++ b/docs/client-sdk/client-sdk-porting-guide.md
@@ -29,6 +29,7 @@ The Client SDK reference implementation source code is organized as follows (fol
 ├── app  - - - - - - Reference Application
 ├── crypto*  - - - - Crypto Subsystem
 ├── cmake* - - - - - cmake sub files
+├── cse - - - - - - - CSE (Client Side Encryption) Subsystem
 ├── data - - - - - - Filesystem place to store blob like keys, network info.
 ├── device_modules - ServiceInfo Modules
 ├── docs - - - - - - Documents
@@ -54,6 +55,8 @@ The build system uses cmake. This section explains the most prominent configurat
 │   └── pristine.cmake
 ├── CMakeLists.txt
 ├── crypto
+│   └── CMakeLists.txt
+├── cse
 │   └── CMakeLists.txt
 ├── device_modules
 │   └── CMakeLists.txt
@@ -93,6 +96,10 @@ set (BLOB_PATH .)
 set (TPM2_TCTI_TYPE tabrmd)
 set (RESALE true)
 set (REUSE true)
+
+#for CSE
+set (CSE_SHUTDOWN true)
+set (CSE_CLEAR false)
 ```
 #### blob_path.cmake
 The blob specific paths are set with this cmake file. A new variable BLOB_PATH is introduced to customize the placement of blobs in the filesystem.

--- a/docs/client-sdk/client-sdk-porting-guide.md
+++ b/docs/client-sdk/client-sdk-porting-guide.md
@@ -29,7 +29,7 @@ The Client SDK reference implementation source code is organized as follows (fol
 ├── app  - - - - - - Reference Application
 ├── crypto*  - - - - Crypto Subsystem
 ├── cmake* - - - - - cmake sub files
-├── cse - - - - - - - CSE (Client Side Encryption) Subsystem
+├── cse - - - - - - - CSE (Converged Security Engine) Subsystem
 ├── data - - - - - - Filesystem place to store blob like keys, network info.
 ├── device_modules - ServiceInfo Modules
 ├── docs - - - - - - Documents
@@ -75,15 +75,18 @@ The base.mk was used to define the build flags as a top-level configuration Make
 
 The following specifies the default build configuration which can be overridden in invocation of cmake.
 ```
+# cmake given defaults
 set (TARGET_OS linux)
 set (CSTD c99)
 set (TLS openssl)
 set (DA ecdsa384)
 set (AES_MODE gcm)
-set (BUILD debug)
+set (BUILD release)
 set (TARGET_OS linux)
 set (HTTPPROXY true)
 set (PROXY_DISCOVERY false)
+set (SELF_SIGNED_CERTS true)
+set (SNI true)
 set (OPTIMIZE 1)
 set (DA_FILE der)
 set (CRYPTO_HW false)
@@ -100,6 +103,16 @@ set (REUSE true)
 #for CSE
 set (CSE_SHUTDOWN true)
 set (CSE_CLEAR false)
+
+#following are specific to only mbedos
+set (DATASTORE sd)
+set (WIFI_SSID " ")
+set (WIFI_PASS " ")
+# TO-DO : This flag is no longer being used in the source.
+# Explore use of the alternative MANUFACTURER_ADDR instead.
+set (MANUFACTURER_IP " ")
+set (MANUFACTURER_DN " ")
+
 ```
 #### blob_path.cmake
 The blob specific paths are set with this cmake file. A new variable BLOB_PATH is introduced to customize the placement of blobs in the filesystem.

--- a/docs/client-sdk/client-sdk-reference-guide.md
+++ b/docs/client-sdk/client-sdk-reference-guide.md
@@ -26,7 +26,7 @@ Like any SDK, the Client SDK is expected to be embedded within a custom implemen
 
 Figure 1.	FDO Client Block Diagram
 
-![FDO Client Block Diagram](img/1-Intel FDO Client Block Diagram.JPG)
+![FDO Client Block Diagram](img/1-Intel%20FDO%20Client%20Block%20Diagram.JPG)
 
 ***NOTE:*** FDO is an acronym for FIDO Device Onboard.
 
@@ -80,7 +80,7 @@ This SDK release requires all software components to be linked together into a s
 
 Figure 2.	Integrated Image and Execution Flow
 
-![FDO Client Block Diagram](img/2-Integrated Image and Execution Flow.JPG)
+![FDO Client Block Diagram](img/2-Integrated%20Image%20and%20Execution%20Flow.JPG)
 
 The integrated image and execution flows from system boot are shown above and each step is described below:
 
@@ -103,7 +103,7 @@ Each of these is described as follows:
 
 Figure 3.	ServiceInfo Exchanges between Device and Owner Server
 
-![FDO Client Block Diagram](img/3-ServiceInfo Exchanges between Device and Owner Server.JPG)
+![FDO Client Block Diagram](img/3-Service%20Info%20Exchanges%20between%20Device%20and%20Owner%20Server.JPG)
 
 #### Module Initialization
 For each registered module, the SDK initializes the module by calling its callback with the `FDO_SI_START` type. The module is expected to prepare to receive PSI, Device ServiceInfo, and Owner ServiceInfo calls after initialization.


### PR DESCRIPTION
Changes made in this PR :-
1. Changed Fido to FIDO
2. Added cse folder in the code structure of porting guide
3. Added CMakeLists.txt under cse folder
4. Added default cse flags in csdk porting guide
5. Changed the links of image in the markdown