### PR TITLE
Added documentation pages for TPM, CSE

### DIFF
--- a/docs/client-sdk/client-sdk-cse.md
+++ b/docs/client-sdk/client-sdk-cse.md
@@ -27,7 +27,6 @@ This function gets the device certificate from the CSE. It takes a pointer to a 
 
 <!-- 2 -->
 
-
 ## cse_get_cose_sig_structure()
 
 Interface to get COSE signature structure.
@@ -53,7 +52,6 @@ This function gets the COSE signature structure. It takes a pointer to a byte ar
 - `-1`: If there is a failure during the COSE signature structure retrieval process.
 
 <!-- 3 -->
-
 
 ## cse_get_test_sig()
 
@@ -85,7 +83,6 @@ This function gets the test signature from the CSE. It takes a pointer to a byte
 
 <!-- 4 -->
 
-
 ## cse_load_file()
 
 Loads the data from CSE storage.
@@ -111,3 +108,108 @@ This function loads the data from CSE storage. It takes a file ID, a pointer to 
 
 - `0`: If the data is successfully loaded from CSE storage.
 - `-1`: If there is a failure during the data loading process.
+
+<!-- 5 -->
+
+## crypto_hal_ecdsa_sign_cse()
+
+Signs a message using CSE API.
+
+```c
+int32_t crypto_hal_ecdsa_sign_cse(const uint8_t *data, size_t data_len,
+                  uint8_t *message_signature,
+                  size_t message_sig_len, uint8_t *eat_maroe,
+                  size_t *maroe_length)
+```
+
+### Description
+
+This function signs a message using CSE API. It takes a pointer to a data buffer, the size of the data buffer, a pointer to a message signature buffer, the size of the message signature buffer, a pointer to a maroeprefix buffer, and the size of the maroeprefix buffer as input, and returns a status for the API function.
+
+### Parameters
+
+- `data`: Pointer to a data buffer.
+- `data_len`: Size of the data buffer.
+- `message_signature`: Pointer to a message signature buffer.
+- `message_sig_len`: Size of the message signature buffer.
+- `eat_maroe`: Pointer to a maroeprefix buffer.
+- `maroe_length`: Size of the maroeprefix buffer.
+
+### Return Value
+
+- `0`: If the message is successfully signed using CSE API.
+- `-1`: If there is a failure during the message signing process.
+
+<!-- 6 -->
+
+## crypto_hal_hmac_cse()
+
+Calculates HMAC on input data.
+
+```c
+int32_t crypto_hal_hmac_cse(uint8_t *buffer, size_t buffer_length,
+                uint8_t *output, size_t output_length)
+```
+
+### Description
+
+This function calculates HMAC on input data. It takes a pointer to an input data buffer, the size of the input data buffer, a pointer to an output data buffer, and the size of the output data buffer as input, and returns a status for the API function.
+
+### Parameters
+
+- `buffer`: Pointer to an input data buffer.
+- `buffer_length`: Size of the input data buffer.
+- `output`: Pointer to an output data buffer.
+- `output_length`: Size of the output data buffer.
+
+### Return Value
+
+- `0`: If the HMAC is successfully calculated on input data.
+- `-1`: If there is a failure during the HMAC calculation process.
+
+<!-- 7 -->
+
+## read_cse_device_credentials()
+
+Populates the dev_cred structure by loading the OVH and DS file data from CSE flash.
+
+```c
+bool read_cse_device_credentials(fdo_dev_cred_t *our_dev_cred)
+```
+
+### Description
+
+This function populates the dev_cred structure by loading the OVH and DS file data from CSE flash. It takes a pointer to the device credentials block as input, and returns a status for the API function.
+
+### Parameters
+
+- `our_dev_cred`: Pointer to the device credentials block.
+
+### Return Value
+
+- `true`: If the dev_cred structure is successfully populated.
+- `false`: If there is a failure during the dev_cred structure population process.
+
+<!-- 8 -->
+
+## fdo_ov_hdr_cse_load_hmac()
+
+Given an OwnershipVoucher header (OVHeader), proceeds to load and compares with stored OVHeader from CSE. If verification succeeds, it returns the stored HMAC.
+
+```c
+bool fdo_ov_hdr_cse_load_hmac(fdo_byte_array_t *ovheader, fdo_hash_t **hmac)
+```
+
+### Description
+
+This function given an OwnershipVoucher header (OVHeader), proceeds to load and compares with stored OVHeader from CSE. If verification succeeds, it returns the stored HMAC. It takes a pointer to the received CBOR-encoded OVHeader, and a pointer to the resulting HMAC as input, and returns a status for the API function.
+
+### Parameters
+
+- `ovheader`: Pointer to the received CBOR-encoded OVHeader.
+- `hmac`: Pointer to the resulting HMAC.
+
+### Return Value
+
+- `true`: If the HMAC was successfully loaded and verified.
+- `false`: If there is a failure during the HMAC loading and verification process.

--- a/docs/client-sdk/client-sdk-cse.md
+++ b/docs/client-sdk/client-sdk-cse.md
@@ -1,0 +1,113 @@
+# FIDO Device Onboard (FDO) Client SDK CSE API Reference
+
+This document describes the list of all the functions used by the client SDK to interact with the CSE (Converged Security Engine).
+
+<!-- 1 -->
+
+## cse_get_cert_chain()
+
+Interface to get device certificate from CSE.
+
+```c
+int32_t cse_get_cert_chain(fdo_byte_array_t **cse_cert)
+```
+
+### Description
+
+This function gets the device certificate from the CSE. It takes a pointer to a byte array as input, and returns a pointer to a byte array holding a valid device CSE certificate.
+
+### Parameters
+
+- `cse_cert`: Pointer to a byte array holding a valid device CSE certificate.
+
+### Return Value
+
+- `0`: If the device certificate is successfully retrieved from the CSE.
+- `-1`: If there is a failure during the device certificate retrieval process.'
+
+<!-- 2 -->
+
+
+## cse_get_cose_sig_structure()
+
+Interface to get COSE signature structure.
+
+```c
+int32_t cse_get_cose_sig_structure(fdo_byte_array_t **cose_sig_structure,
+                   uint8_t *data, size_t data_len)
+```
+
+### Description
+
+This function gets the COSE signature structure. It takes a pointer to a byte array, a pointer to a data buffer, and the size of the data buffer as input, and returns a pointer to a byte array holding a COSE signature structure.
+
+### Parameters
+
+- `cose_sig_structure`: Pointer to a byte array holding a COSE signature structure.
+- `data`: Pointer to a data buffer.
+- `data_len`: Size of the data buffer.
+
+### Return Value
+
+- `0`: If the COSE signature structure is successfully retrieved.
+- `-1`: If there is a failure during the COSE signature structure retrieval process.
+
+<!-- 3 -->
+
+
+## cse_get_test_sig()
+
+Interface to get test signature from CSE.
+
+```c
+int32_t cse_get_test_sig(fdo_byte_array_t **cse_signature,
+             fdo_byte_array_t **cse_maroeprefix,
+             fdo_byte_array_t *cose_sig_structure, uint8_t *data,
+             size_t data_len)
+```
+
+### Description
+
+This function gets the test signature from the CSE. It takes a pointer to a byte array, a pointer to a byte array, a pointer to a COSE signature structure, a pointer to a data buffer, and the size of the data buffer as input, and returns a pointer to a byte array holding a valid device CSE test signature.
+
+### Parameters
+
+- `cse_signature`: Pointer to a byte array holding a valid device CSE test signature.
+- `cse_maroeprefix`: Pointer to a byte array holding a valid device CSE maroeprefix.
+- `cose_sig_structure`: Pointer to a COSE signature structure.
+- `data`: Pointer to a data buffer.
+- `data_len`: Size of the data buffer.
+
+### Return Value
+
+- `0`: If the test signature is successfully retrieved.
+- `-1`: If there is a failure during the test signature retrieval process.
+
+<!-- 4 -->
+
+
+## cse_load_file()
+
+Loads the data from CSE storage.
+
+```c
+int32_t cse_load_file(uint32_t file_id, uint8_t *data_ptr,
+          uint32_t *data_length, uint8_t *hmac_ptr, size_t hmac_sz)
+```
+
+### Description
+
+This function loads the data from CSE storage. It takes a file ID, a pointer to a data buffer, a pointer to the size of the data buffer, a pointer to a HMAC buffer, and the size of the HMAC buffer as input, and returns a status for the API function.
+
+### Parameters
+
+- `file_id`: File ID type Device status or OVH.
+- `data_ptr`: Pointer to a data buffer.
+- `data_length`: Pointer to the size of the data buffer.
+- `hmac_ptr`: Pointer to a HMAC buffer.
+- `hmac_sz`: Size of the HMAC buffer.
+
+### Return Value
+
+- `0`: If the data is successfully loaded from CSE storage.
+- `-1`: If there is a failure during the data loading process.

--- a/docs/client-sdk/client-sdk-cse.md
+++ b/docs/client-sdk/client-sdk-cse.md
@@ -1,4 +1,4 @@
-# FIDO Device Onboard (FDO) Client SDK CSE API Reference
+# FIDO Device Onboard (FDO) Client SDK Intel® CSE API Reference
 
 This document describes the list of all the functions used by the client SDK to interact with the CSE (Converged Security Engine).
 

--- a/docs/client-sdk/client-sdk-tmp.md
+++ b/docs/client-sdk/client-sdk-tmp.md
@@ -1,0 +1,335 @@
+# FIDO Device Onboard (FDO) Client SDK TPM API Reference
+
+This section describes list of all the functions used by the client SDK to interact with the TPM.
+
+<!-- 1 -->
+## fdo_tpm_get_hmac()
+
+Generates HMAC using TPM.
+
+```c
+int32_t fdo_tpm_get_hmac(const uint8_t *data, size_t data_length, uint8_t *hmac,
+                         size_t hmac_length, char *tpmHMACPub_key,
+                         char *tpmHMACPriv_key);
+```
+
+### Description
+
+This function generates HMAC (Hash-based Message Authentication Code) using the Trusted Platform Module (TPM). It takes input data, calculates its HMAC using TPM, and stores the result in the output buffer provided.
+
+### Parameters
+
+- `data`: Pointer to the input data for which HMAC needs to be generated.
+- `data_length`: Length of the input data in bytes.
+- `hmac`: Pointer to the output buffer where the generated HMAC will be saved.
+- `hmac_length`: Length of the output HMAC buffer in bytes.
+- `tpmHMACPub_key`: File name of the TPM HMAC public key. (It's likely used to access the TPM key for HMAC generation.)
+- `tpmHMACPriv_key`: File name of the TPM HMAC private key. (This key is used along with the public key for HMAC generation.)
+
+### Return Value
+
+- `0`: If the HMAC generation is successful.
+- `-1`: If there is a failure during the HMAC generation process.
+
+
+<!-- 2 -->
+
+## fdo_tpm_generate_hmac_key()
+
+Generates HMAC key inside TPM.
+
+```c
+int32_t fdo_tpm_generate_hmac_key(char *tpmHMACPub_key, char *tpmHMACPriv_key);
+```
+
+### Description
+
+This function generates HMAC key inside the TPM. It takes the file names of the TPM HMAC public and private keys as input.
+
+### Parameters
+
+- `tpmHMACPub_key`: File name of the TPM HMAC public key.
+- `tpmHMACPriv_key`: File name of the TPM HMAC private key.
+
+### Return Value
+
+- `0`: If the HMAC key generation is successful.
+- `-1`: If there is a failure during the HMAC key generation process.
+
+<!-- 3 -->
+
+## fdoTPMGenerate_primary_key_context()
+
+Generates TPM primary key context from the endorsement hierarchy.
+
+```c
+int32_t fdoTPMGenerate_primary_key_context(ESYS_CONTEXT **esys_context,
+                                             ESYS_TR *primary_key_handle,
+                                             ESYS_TR *auth_session_handle);
+```
+
+### Description
+
+This function generates the TPM primary key context from the endorsement hierarchy. It takes the Esys context, primary key handle, and authentication session handle as input.
+
+### Parameters
+
+- `esys_context`: Output Esys context.
+- `primary_key_handle`: Output primary key handle.
+- `auth_session_handle`: Output authentication session handle for Esys API.
+
+### Return Value
+
+- `0`: If the TPM primary key context generation is successful.
+- `-1`: If there is a failure during the TPM primary key context generation process.
+
+<!-- 4 -->
+
+## fdoTPMEsys_context_init()
+
+Initializes the Esys context.
+
+```c
+int32_t fdoTPMEsys_context_init(ESYS_CONTEXT **esys_context);
+```
+
+### Description
+
+This function initializes the Esys context. It takes the Esys context as input.
+
+### Parameters
+
+- `esys_context`: Output Esys context.
+
+### Return Value
+
+- `0`: If the Esys context initialization is successful.
+- `-1`: If there is a failure during the Esys context initialization process.
+
+<!-- 5 -->
+
+## fdoTPMEsys_auth_session_init()
+
+Creates HMAC-based authentication session for Esys context.
+
+```c
+int32_t fdoTPMEsys_auth_session_init(ESYS_CONTEXT *esys_context,
+                                       ESYS_TR *session_handle);
+```
+
+### Description
+
+This function creates HMAC-based authentication session for Esys context. It takes the Esys context and authentication session handle as input.
+
+### Parameters
+
+- `esys_context`: Input Esys context.
+- `session_handle`: Output authentication session handle.
+
+### Return Value
+
+- `0`: If the HMAC-based authentication session creation is successful.
+- `-1`: If there is a failure during the HMAC-based authentication session creation process.
+
+<!-- 6 -->
+
+## fdoTPMTSSContext_clean_up()
+
+Clears the Esys, TCTI, contexts, and authentication session, primary key handles.
+
+```c
+int32_t fdoTPMTSSContext_clean_up(ESYS_CONTEXT **esys_context,
+                                    ESYS_TR *auth_session_handle,
+                                    ESYS_TR *primary_handle);
+```
+
+### Description
+
+This function clears the Esys, TCTI, contexts, and authentication session, primary key handles. It takes the Esys context, authentication session handle, and primary key handle as input.
+
+### Parameters
+
+- `esys_context`: Input Esys context.
+- `auth_session_handle`: Input authentication session handle.
+- `primary_handle`: Input primary key handle.
+
+### Return Value
+
+- `0`: If the Esys, TCTI, contexts, and authentication session, primary key handles are cleared successfully.
+- `-1`: If there is a failure during the Esys, TCTI, contexts, and authentication session, primary key handles clearing process.
+
+<!-- 7 -->
+
+## fdo_tpm_commit_replacement_hmac_key()
+
+Replaces the TPM HMAC private and public keys with the replacement keys.
+
+```c
+int32_t fdo_tpm_commit_replacement_hmac_key(void);
+```
+
+### Description
+
+This function replaces the TPM HMAC private and public keys with the replacement keys.
+
+### Parameters
+
+None.
+
+### Return Value
+
+- `0`: If the replacement of the TPM HMAC private and public keys is successful.
+- `-1`: If there is a failure during the replacement of the TPM HMAC private and public keys process.
+
+<!-- 8 -->
+
+## fdo_tpm_clear_replacement_hmac_key()
+
+Clears the replacement TPM HMAC key objects, if they exist.
+
+```c
+void fdo_tpm_clear_replacement_hmac_key(void);
+```
+
+### Description
+
+This function clears the replacement TPM HMAC key objects, if they exist.
+
+### Parameters
+
+None.
+
+### Return Value
+
+None.
+
+<!-- 9 -->
+
+## is_valid_tpm_data_protection_key_present()
+
+Checks whether a valid data integrity protection HMAC key is present or not.
+
+```c
+int32_t is_valid_tpm_data_protection_key_present(void);
+```
+
+### Description
+
+This function checks whether a valid data integrity protection HMAC key is present or not.
+
+### Parameters
+
+None.
+
+### Return Value
+
+- `1`: If a valid data integrity protection HMAC key is present.
+- `0`: If a valid data integrity protection HMAC key is not present.
+
+<!-- 10 -->
+
+## crypto_hal_ecdsa_sign()
+
+Signs a message using provided ECDSA private keys.
+
+```c
+int32_t crypto_hal_ecdsa_sign(const uint8_t *data, size_t data_len,
+                              unsigned char *message_signature,
+                              size_t *signature_length);
+```
+
+### Description
+
+This function signs a message using provided ECDSA private keys. It takes the message, message length, message signature, and signature length as input.
+
+### Parameters
+
+- `data`: Input message.
+- `data_len`: Input message length.
+- `message_signature`: Output message signature.
+- `signature_length`: Output signature length.
+
+### Return Value
+
+- `0`: If the message signing is successful.
+- `-1`: If there is a failure during the message signing process.
+
+<!-- 11 -->
+
+## Tss2_MU_TPM2B_PRIVATE_Unmarshal()
+
+Generates HMAC using TPM.
+
+
+```c
+int32_t Tss2_MU_TPM2B_PRIVATE_Unmarshal(
+    const uint8_t *buffer, size_t buffer_size, size_t *offset,
+    TPM2B_PRIVATE *out);
+```
+
+### Description
+
+This function generates HMAC using TPM. It takes the buffer, buffer size, offset, and TPM2B_PRIVATE as input.
+
+### Parameters
+
+- `data` - pointer to the input data
+- `data_length` - length of the input data
+- `hmac` - output buffer to save the HMAC
+- `hmac_length` - length of the output HMAC buffer hash length
+- `tpmHMACPub_key` - File name of the TPM HMAC public key
+- `tpmHMACPriv_key` - File name of the TPM HMAC private key
+
+### Return Value
+
+- `0`: If the HMAC generation is successful.
+- `-1`: If there is a failure during the HMAC generation process.
+
+<!-- 12 -->
+## Tss2_MU_TPM2B_PUBLIC_Unmarshal()
+
+Generates HMAC using TPM.
+
+```c
+int32_t Tss2_MU_TPM2B_PUBLIC_Unmarshal(
+    const uint8_t *buffer, size_t buffer_size, size_t *offset,
+    TPM2B_PUBLIC *out);
+```
+
+### Description
+
+This function generates HMAC using TPM. It takes the buffer, buffer size, offset, and TPM2B_PUBLIC as input.
+
+### Parameters
+
+- `data` - pointer to the input data
+- `data_length` - length of the input data
+- `hmac` - output buffer to save the HMAC
+- `hmac_length` - length of the output HMAC buffer hash length
+- `tpmHMACPub_key` - File name of the TPM HMAC public key
+- `tpmHMACPriv_key` - File name of the TPM HMAC private key
+
+### Return Value
+
+- `0`: If the HMAC generation is successful.
+- `-1`: If there is a failure during the HMAC generation process.
+
+## Constants
+
+If the TPM is configured with ECDSA256_DA, then the following constants are defined:
+
+- `TPM_HMAC_PRIV_KEY_CONTEXT_SIZE_128`: 128
+- `FDO_TPM2_CURVE_ID`: TPM2_ECC_NIST_P256
+- `TPM_AES_BITS`: 128
+- `FDO_TPM2_ALG_SHA`: TPM2_ALG_SHA256
+- `TPM_HMAC_PRIV_KEY_CONTEXT_SIZE`: 160
+- `TPM_HMAC_PUB_KEY_CONTEXT_SIZE`: 48
+
+If the TPM is not configured with ECDSA256_DA, then the following constants are defined:
+
+- `TPM_HMAC_PRIV_KEY_CONTEXT_SIZE_128`: 128
+- `FDO_TPM2_CURVE_ID`: TPM2_ECC_NIST_P384
+- `TPM_AES_BITS`: 256
+- `FDO_TPM2_ALG_SHA`: TPM2_ALG_SHA384
+- `TPM_HMAC_PRIV_KEY_CONTEXT_SIZE`: 224
+- `TPM_HMAC_PUB_KEY_CONTEXT_SIZE`: 64


### PR DESCRIPTION
Added the Github.io documentation for TPM for the following functions:- 

1. fdo_tpm_get_hmac()
2. fdo_tpm_generate_hmac_key()
3. fdoTPMGenerate_primary_key_context()
4. fdoTPMEsys_context_init()
5. fdoTPMEsys_auth_session_init()
6. fdoTPMTSSContext_clean_up()
7. fdo_tpm_commit_replacement_hmac_key()
8. fdo_tpm_clear_replacement_hmac_key()
9. is_valid_tpm_data_protection_key_present()
10. crypto_hal_ecdsa_sign()
11. Tss2_MU_TPM2B_PRIVATE_Unmarshal()
12. Tss2_MU_TPM2B_PUBLIC_Unmarshal()

Added the Github.io documentation for CSE for the following functions:- 

1. cse_get_cert_chain()
2. cse_get_cose_sig_structure()
3. cse_get_test_sig()
4. cse_load_file()
5. crypto_hal_ecdsa_sign_cse()
6. crypto_hal_hmac_cse()
7. read_cse_device_credentials()
8. fdo_ov_hdr_cse_load_hmac()