### PR TITLE
Github.io docs changes

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -2,7 +2,7 @@
 
 Welcome to the FIDO Device Onboard community. FIDO Device Onboard is an open source project sponsored by [LF Edge](https://www.lfedge.org/projects/fidodeviceonboard/).
 
-Community practices are documented at the [Secure Device Onboard wiki](https://wiki.lfedge.org/display/LE/Secure+Device+Onboard).
+Community practices are documented at the [Fido Device Onboard wiki](https://www.lfedge.org/projects/fidodeviceonboard).
 
 For details, refer to the following topics:
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -2,7 +2,7 @@
 
 Welcome to the FIDO Device Onboard community. FIDO Device Onboard is an open source project sponsored by [LF Edge](https://www.lfedge.org/projects/fidodeviceonboard/).
 
-Community practices are documented at the [Fido Device Onboard wiki](https://www.lfedge.org/projects/fidodeviceonboard).
+Community practices are documented at the [FIDO Device Onboard wiki](https://www.lfedge.org/projects/fidodeviceonboard).
 
 For details, refer to the following topics:
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -2,7 +2,7 @@
 
 Welcome to the FIDO Device Onboard community. FIDO Device Onboard is an open source project sponsored by [LF Edge](https://www.lfedge.org/projects/fidodeviceonboard/).
 
-Community practices are documented at the [Secure Device Onboard wiki](https://wiki.lfedge.org/display/SDO/Secure+Device+Onboard).
+Community practices are documented at the [Secure Device Onboard wiki](https://wiki.lfedge.org/display/LE/Secure+Device+Onboard).
 
 For details, refer to the following topics:
 

--- a/docs/implementation-references/getting-started-guide.md
+++ b/docs/implementation-references/getting-started-guide.md
@@ -18,14 +18,25 @@ The FDO project provides a reference implementation of the [FIDO specification](
 
 This document provides a quick walk through the E2E flow. Included in this guide:
 
-- [Quick Overview of FDO](#quick-overview-of-fdo)
-- [Building FDO PRI Source](#building-fdo-pri-source)
-- [Starting FDO Service Containers](#starting-fdo-server-side-containers)
-- [Running E2E for PRI device](#running-e2e-for-pri-device)
-- [Building Client-SDK Source](#building-client-sdk-source)
-- [Running E2E for Client-SDK device](#running-e2e-demo-for-fdo-client-sdk)
-- [Enabling ServiceInfo](#enabling-serviceinfo-transfer)
-- [Keystore Management](#keystore-management)
+- [Getting Started Guide](#getting-started-guide)
+  - [Quick Overview of FDO](#quick-overview-of-fdo)
+  - [Building FDO PRI Source](#building-fdo-pri-source)
+  - [Starting FDO Server-side Containers](#starting-fdo-server-side-containers)
+    - [Key Generation for FDO Server-side Containers](#key-generation-for-fdo-server-side-containers)
+    - [Specifying Subject alternate names for the Web/HTTPS self-signed certificate](#specifying-subject-alternate-names-for-the-webhttps-self-signed-certificate)
+    - [Enable DIGEST REST endpoints](#enable-digest-rest-endpoints)
+    - [Starting the FDO PRI Manufacturer Server](#starting-the-fdo-pri-manufacturer-server)
+    - [Starting the FDO PRI Rendezvous (RV) Server](#starting-the-fdo-pri-rendezvous-rv-server)
+  - [Running E2E for PRI Device](#running-e2e-for-pri-device)
+  - [Building Client-SDK Source](#building-client-sdk-source)
+  - [Running E2E Demo for FDO Client-SDK](#running-e2e-demo-for-fdo-client-sdk)
+        - [1. Start FDO Service Containers.](#1-start-fdo-service-containers)
+        - [2. Start Device Initialization (DI)](#2-start-device-initialization-di)
+        - [Voucher Extension for Client-SDK Device](#voucher-extension-for-client-sdk-device)
+        - [TO1 and TO2](#to1-and-to2)
+  - [Enabling ServiceInfo Transfer](#enabling-serviceinfo-transfer)
+  - [Keystore Management](#keystore-management)
+    - [Generating Self-signed keys for HTTPS/TLS Communication.](#generating-self-signed-keys-for-httpstls-communication)
 
 
 ## Quick Overview of FDO
@@ -221,20 +232,20 @@ Uncomment `subjectAltName` and allowed list of IP and DNS in `[alt_names]` secti
       </login-config>
     ```
     Change `<transport-guarantee>` to `NONE` and `<auth-method>` to `DIGEST`.
-    
+
 2. Update `{server.api.user}` and `{server.api.password}` in `demo/<component>/tomcat-users.xml` file.
 
 
 ### Starting the FDO PRI Manufacturer Server
 
-***FDO Manufacturer is an application that runs in the factory, which implements the initial communications with the Device, as part of the Device Initialize Protocol (DI). The manufacturer creates an Ownership Voucher based on the credentials received during DI and extends the voucher to the respective owner.***    
+***FDO Manufacturer is an application that runs in the factory, which implements the initial communications with the Device, as part of the Device Initialize Protocol (DI). The manufacturer creates an Ownership Voucher based on the credentials received during DI and extends the voucher to the respective owner.***
 
 Run the below commands, in a separate console, to start the Manufacturer.
 
 ```
 cd <fdo-pri-src>/component-samples/demo/manufacturer/
 sudo docker-compose up --build
-```   
+```
 Once the Manufacturer has successfully started, the following output is displayed
 <figure>
   <center>
@@ -245,7 +256,7 @@ Once the Manufacturer has successfully started, the following output is displaye
 
 ### Starting the FDO PRI Rendezvous (RV) Server
 
-***RV Server is a network server or service (For example, on the Internet) that acts as a rendezvous point between a newly powered on Device and the Owner Onboarding Service.***   
+***RV Server is a network server or service (For example, on the Internet) that acts as a rendezvous point between a newly powered on Device and the Owner Onboarding Service.***
 
 Run the below commands, on a seperate console, to start the RV server.
 
@@ -263,7 +274,7 @@ Once the RV instance has successfully started, the following output is displayed
 
 ###Starting the FDO PRI Owner Server
 
-***Owner is an entity that is able to prove ownership to the Device using an Ownership Voucher and a private key for the last entry of the Ownership Voucher. Owner supports the transfer of Serviceinfo to the Device.***   
+***Owner is an entity that is able to prove ownership to the Device using an Ownership Voucher and a private key for the last entry of the Ownership Voucher. Owner supports the transfer of Serviceinfo to the Device.***
 
 Run the below commands, on a separate console, to start the Owner Server.
 
@@ -343,7 +354,7 @@ cd <fdo-pri-src>/component-samples/demo/scripts
 bash extend_upload.sh -e mtls -c <path-to-generated-secrets> -s serial_no
 ```
 
-or 
+or
 
 Follow the steps to manually initiate the T00.
 
@@ -466,7 +477,7 @@ cd <fdo-pri-src>/component-samples/demo/scripts
 bash extend_upload.sh -e mtls -c <path-to-generated-secrets> -s serial_no
 ```
 
-or 
+or
 
 ```
 curl -D - --digest -u ${api_user}:${owner_api_passwd} --location --request GET "http://${owner_ip}:${onr_port}/api/v1/certificate?alias=${attestation_type}" -H 'Content-Type: text/plain' -o owner_cert.txt

--- a/docs/implementation-references/getting-started-guide.md
+++ b/docs/implementation-references/getting-started-guide.md
@@ -10,7 +10,7 @@ The FDO project provides a reference implementation of the [FIDO specification](
 
 <figure markdown="1">
    <center>
-        <img src="../../images/securedeviceonboard-icon-color.png" width="40%" />
+        <img src="../images/securedeviceonboard-icon-color.png" width="40%" />
    </center>
 </figure>
 
@@ -77,7 +77,7 @@ FDO consists of four sets of protocols namely **DI, TO0, TO1, and TO2**.
     - When working behind a proxy, ensure to [set proper proxy](https://fido-device-onboard.github.io/docs-fidoiot/latest/implementation-references/proxy-settings/) variables.
     - [Follow the steps](https://docs.docker.com/engine/install/ubuntu/) to setup Docker* environment.
     - [Follow the steps](https://fido-device-onboard.github.io/docs-fidoiot/latest/installation/#running-the-docker-behind-a-proxy) to setup Docker* proxy.
-    - [Follow the steps](../../implementation-references/proxy-settings/) to set the right proxy settings. (Includes documentation for system wide proxy configuration)
+    - [Follow the steps](../implementation-references/proxy-settings.md) to set the right proxy settings. (Includes documentation for system wide proxy configuration)
 
 1.&nbsp; Clone the PRI-fidoiot repository
 ```
@@ -125,7 +125,7 @@ The build stage generates artifacts and stores them in `component-samples/demo` 
 
 <figure>
   <center>
-  <img src="../../images/entities.png"/>
+  <img src="../images/entities.png"/>
   <figcaption> FIDO Device Onboard Entities and Entity Interconnection </figcaption>
   </center>
 </figure>
@@ -238,7 +238,7 @@ sudo docker-compose up --build
 Once the Manufacturer has successfully started, the following output is displayed
 <figure>
   <center>
-  <img src="../../images/manufacturer.png"/>
+  <img src="../images/manufacturer.png"/>
   <figcaption> Manufacturer getting started </figcaption>
   </center>
 </figure>
@@ -256,7 +256,7 @@ sudo docker-compose up --build
 Once the RV instance has successfully started, the following output is displayed
 <figure>
   <center>
-  <img src="../../images/rv.png"/>
+  <img src="../images/rv.png"/>
   <figcaption>RV getting started </figcaption>
   </center>
 </figure>
@@ -274,7 +274,7 @@ sudo docker-compose up --build
 Once the Owner instance has successfully started, the following output is displayed
 <figure>
  <center>
-  <img src="../../images/owner.png"/>
+  <img src="../images/owner.png"/>
   <figcaption> Owner getting started </figcaption>
  </center>
 </figure>
@@ -283,7 +283,7 @@ Once the Owner instance has successfully started, the following output is displa
       - Proper [keystore management](#keystore-management) to be considered before using the services in production environment.
       - To0scheduling interval property can be modified in the component-sample/demo/owner/service.yml.
       Update to0-scheduler: `interval: 120`
-      - [Read more](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/component-samples/demo/README.md) about starting PRI services.
+      - [Read more](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/component-samples/demo/README.MD) about starting PRI services.
 
 ## Running E2E for PRI Device
 
@@ -321,7 +321,7 @@ DI complete, GUID is <guid>
 
 <figure>
   <center>
-  <img src="../../images/Slide3.PNG"/>
+  <img src="../images/Slide3.PNG"/>
   <figcaption>Voucher extension</figcaption>
   </center>
 </figure>
@@ -594,6 +594,6 @@ Device onboarded successfully.
     ```
 
 !!!NOTES
-    - [Read more](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/component-samples/demo/README.md#generating-key-pair) about key generation.
+    - [Read more](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/component-samples/demo/README.MD#generating-key-pair) about key generation.
     - You can update the key type, by modifying the `-newkey` attribute during the key generation stage.
     - You can add multiple IP addresses in the `subjectAltName` attribute.

--- a/docs/implementation-references/manufacturer-guide.md
+++ b/docs/implementation-references/manufacturer-guide.md
@@ -50,4 +50,4 @@ The following are the implied requirements:
 ### Supply Chain Requirements
 FDO requires support from your supply chain partners. Specially, they will need to deploy the means to manage and extend ownership vouchers. As physical devices come into their inventory they will need to associate those devices with the respective ownership vouchers. Then as those device are resold, the vouchers will need to be extended to the next owner in the supply chain. 
 
-To support this process, there is a reseller component sample that can perform the storage and extension of ownership vouchers. See [Component Reseller](https://github.com/fido-device-onboard/pri-fidoiot/tree/master/component-samples/reseller) for details.
+To support this process, there is a reseller component sample that can perform the storage and extension of ownership vouchers. See [Component Reseller](https://github.com/fido-device-onboard/pri-fidoiot/tree/master/component-samples/demo/reseller) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ The [FDO PRI](https://github.com/fido-device-onboard/pri-fidoiot) is a reference
 
 The [FDO Client SDK](https://github.com/fido-device-onboard/client-sdk-fidoiot) is a C-based implementation of the Device component defined in FIDO Device Onboard (FDO) Specification. 
 
-The [Implementation Reference](implementation-reference) includes different guides for integrating
+The [Implementation Reference](https://fido-device-onboard.github.io/docs-fidoiot/latest/implementation-references/getting-started-guide/) includes different guides for integrating
 FDO components for various use-cases.
 
 See the [release notes](https://github.com/fido-device-onboard/release-fidoiot/releases) for a summary of features and capabilities implemented (or not) in different releases.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ This document can be used as a quick start guide to setup the development enviro
 | Docker\* Engine       | 20.10.10+                                            |
 | Docker\* Compose      | 1.29.2                                               |
 | Maven\*               | 3.5.4                                                |
-| Java                  | 11                                                   |
+| Java                  | 17                                                   |
 | Haveged               | -                                                    |
 
 ## Docker\* Installation
@@ -78,12 +78,12 @@ sudo systemctl show --property Environment docker
 
 ## Docker\* Compose Installation
 
-To install a specific version of Docker\* Compose (for example **_1.21.2_**) follow these steps:
+To install a specific version of Docker\* Compose (for example **_1.29.2_**) follow these steps:
 
-1 . Download the specific version **(1.21.2)** of Docker\* Compose.
+1 . Download the specific version **(1.29.2)** of Docker\* Compose.
 
 ```
-sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-`uname -s`-`uname -m` -o /usr/bin/docker-compose
+sudo curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/bin/docker-compose
 ```
 
 2 . To apply executable permissions, run the following command.
@@ -99,7 +99,7 @@ sudo chmod +x /usr/bin/docker-compose
 1 . To install OpenJDK\*
 
 ```
-sudo apt install openjdk-11-jdk-headless
+sudo apt install openjdk-17-jdk-headless
 ```
 
 2 . To install Maven\*
@@ -150,23 +150,7 @@ timedatectl
 
 ## To Set Correct System Time
 
-1. Set System Time from Google HTTP Response Header (Method 1)
-
-```
-sudo date -s "$(wget -qSO- --max-redirect=0 https://google.com/ 2>&1 | grep Date: | cut -d' ' -f5-8)Z"
-```
-
-Sync the hardware clock with the system using the following command
-
-```
-sudo hwclock --systohc
-```
-
-Ensure that the system time is correct, else you will receive the certificate expiration error.
-
-Change the Google\* domain according to your location.
-
-2. Using NTP (Network Time Protocol) (Method 2)
+Using NTP (Network Time Protocol) 
 
 First, ensure that the NTP client is installed on your system. If it's not already installed, you can install it using the following command:
 

--- a/docs/installation_rhel.md
+++ b/docs/installation_rhel.md
@@ -42,7 +42,7 @@ sudo ln -s /usr/local/bin/podman-compose /usr/bin/podman-compose
 
 ### 1 . To install OpenJDK*
 ```
-sudo yum -y install java-11-openjdk-devel
+sudo yum -y install java-17-openjdk-devel
 ```
 
 ### 2 . To install Maven*
@@ -96,13 +96,40 @@ sudo chkconfig haveged on
 ```
 
 ## To Set Correct System Time
+
+Using NTP (Network Time Protocol) 
+
+First, ensure that the NTP client is installed on your system. If it's not already installed, you can install it using the following command:
+
 ```
-sudo date -s "$(wget -qSO- --max-redirect=0 google.com 2>&1 | grep Date: | cut -d' ' -f5-8)Z"
+sudo apt-get update
+sudo apt-get install ntp
 ```
 
-Ensure that the system time is correct, else you will receive the certificate expiration error.
+Open the NTP configuration file for editing. This file typically is located at /etc/ntp.conf. Use your preferred text editor, such as nano or vim:
 
-Change Google* domain according to your location.
+```
+sudo nano /etc/ntp.conf
+```
+
+Replace or add NTP servers based on your location or preference. For example:
+
+```
+server ntp.ubuntu.com
+server pool.ntp.org
+```
+
+Restart the NTP service to apply the configuration changes
+
+```
+sudo systemctl restart ntp
+```
+
+Monitor the NTP synchronization status using the following command:
+
+```
+ntpq -p
+```
 
 ## References
 

--- a/homepage/docs/index.md
+++ b/homepage/docs/index.md
@@ -6,6 +6,7 @@ implementations for FIDO Device Onboard specification.
 Following snapshots are available for different releases of FIDO Device Onboard implementations.
 
 * [latest](https://fido-device-onboard.github.io/docs-fidoiot/latest)
+* [1.1.7](https://fido-device-onboard.github.io/docs-fidoiot/latest)
 * [1.1.6](https://fido-device-onboard.github.io/docs-fidoiot/1.1.6)
 * [1.1.5](https://fido-device-onboard.github.io/docs-fidoiot/1.1.5)
 * [1.1.4](https://fido-device-onboard.github.io/docs-fidoiot/1.1.4)

--- a/homepage/docs/index.md
+++ b/homepage/docs/index.md
@@ -6,7 +6,6 @@ implementations for FIDO Device Onboard specification.
 Following snapshots are available for different releases of FIDO Device Onboard implementations.
 
 * [latest](https://fido-device-onboard.github.io/docs-fidoiot/latest)
-* [1.1.7](https://fido-device-onboard.github.io/docs-fidoiot/latest)
 * [1.1.7](https://fido-device-onboard.github.io/docs-fidoiot/1.1.7)
 * [1.1.6](https://fido-device-onboard.github.io/docs-fidoiot/1.1.6)
 * [1.1.5](https://fido-device-onboard.github.io/docs-fidoiot/1.1.5)

--- a/homepage/docs/index.md
+++ b/homepage/docs/index.md
@@ -7,6 +7,7 @@ Following snapshots are available for different releases of FIDO Device Onboard 
 
 * [latest](https://fido-device-onboard.github.io/docs-fidoiot/latest)
 * [1.1.7](https://fido-device-onboard.github.io/docs-fidoiot/latest)
+* [1.1.7](https://fido-device-onboard.github.io/docs-fidoiot/1.1.7)
 * [1.1.6](https://fido-device-onboard.github.io/docs-fidoiot/1.1.6)
 * [1.1.5](https://fido-device-onboard.github.io/docs-fidoiot/1.1.5)
 * [1.1.4](https://fido-device-onboard.github.io/docs-fidoiot/1.1.4)


### PR DESCRIPTION
1. Removed fetching time from google
2. Adding 1.1.7 version in main docs page
3. Fixing all inactive and broken links 
4. Changing to java 17 from java 11
5. Changing docker compose version to 1.29.2
6. Updating to openjdk 17 from openjdk 11
7. Adding utility to fetch time by ntp in RHEL