### PR TITLE
Correcting the docker-proxy format

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,8 +50,8 @@ Environment="HTTPS_PROXY=<Proxy IP/URL:Port>"
         "default":
         {
             "httpProxy": "<Proxy IP/URL:Port>",
-            "httpsProxy": "<Proxy IP/URL:Port>"
-            "noProxy": "<Proxy IP/URL:Port>"
+            "httpsProxy": "<Proxy IP/URL:Port>",
+            "noProxy": "<Domain names or IP addresses>"
         }
     }
 }


### PR DESCRIPTION
Added comma to distinguish "httpsProxy" and "noProxy"